### PR TITLE
move location of values clause to avoid virtuoso bug

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -57,6 +57,8 @@ async function handleChangedSubjects(subjects: string[]) {
     })
     .join('\n');
 
+  // WARNING personally i would never put the values statement in this query so far away from
+  // its usage, but moving it inside the graph statement triggers a virtuoso error "no SPART_VARR_FIXED"
   update(`
     PREFIX dct: <http://purl.org/dc/terms/>
 
@@ -71,11 +73,11 @@ async function handleChangedSubjects(subjects: string[]) {
       }
     }
     WHERE {
+      VALUES (?subject ?type) {
+        ${subjectsAndTypesValues}
+      }
       GRAPH ?g {
         ?subject a ?type .
-        VALUES (?subject ?type) {
-          ${subjectsAndTypesValues}
-        }
         OPTIONAL { ?subject dct:modified ?modified }
       }
       ${filterModifiedSubjects}


### PR DESCRIPTION
## Description

move location of values clause to avoid virtuoso bug. We get this error from virtuoso if the values clause is inside the graph statement, so we move it outside:

```
 Virtuoso 37000 Error SP031: SPARQL compiler: Internal error: ssg_print_rvr_fixed_val(): no SPART_VARR_FIXED
```
## How to test

Modify a mandataris, you will see a lot of things getting a modified date and the error should not be thrown


