### PR TITLE
fix: remove > from interesting types array

### DIFF
--- a/config/config.ts
+++ b/config/config.ts
@@ -1,7 +1,7 @@
 import { Changeset } from '../types';
 
 export const interestingTypes = [
-  'http://www.w3.org/2004/02/skos/core#Concept>',
+  'http://www.w3.org/2004/02/skos/core#Concept',
 ];
 
 export const filterModifiedSubjects = '';


### PR DESCRIPTION
Added my types to the intersting types array with every string containing `<my-type>` because i saw the `>` at the end of the example. My fault by not checking the full uri but this took some time to realize. 

Removed it from the array