### PR TITLE
add cron to clean up duplicate modified statements in same graph, optional by env var

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,2 @@
-FROM semtech/mu-javascript-template:feature-node-18
+FROM semtech/mu-javascript-template:1.8.0
 LABEL maintainer="karel.kremer@redpencil.io"

--- a/app.ts
+++ b/app.ts
@@ -1,5 +1,6 @@
 import { app, sparqlEscapeUri, sparqlEscapeDateTime } from 'mu';
 import { querySudo as query, updateSudo as update } from '@lblod/mu-auth-sudo';
+import { CronJob } from 'cron';
 
 import { ErrorRequestHandler, Request, Response } from 'express';
 import { Changeset } from './types';
@@ -59,7 +60,7 @@ async function handleChangedSubjects(subjects: string[]) {
 
   // WARNING personally i would never put the values statement in this query so far away from
   // its usage, but moving it inside the graph statement triggers a virtuoso error "no SPART_VARR_FIXED"
-  update(`
+  await update(`
     PREFIX dct: <http://purl.org/dc/terms/>
 
     DELETE {
@@ -86,7 +87,6 @@ async function handleChangedSubjects(subjects: string[]) {
 }
 
 async function handleDelta(req: Request, res: Response) {
-  console.log('incoming delta');
   const changeSets: Changeset[] = req.body;
   const filteredChangeSets = await filterDeltas(changeSets);
   const subjects = new Set<string>();
@@ -95,7 +95,6 @@ async function handleDelta(req: Request, res: Response) {
     changeSet.deletes.forEach((quad) => subjects.add(quad.subject.value));
   });
   await handleChangedSubjects([...subjects]);
-  console.log('handled delta');
 
   res.status(201).send();
 }
@@ -111,3 +110,59 @@ const errorHandler: ErrorRequestHandler = function (err, _req, res, _next) {
 };
 
 app.use(errorHandler);
+
+let cleanupRunning = false;
+const cleanupDuplicateModifieds = async () => {
+  if (cleanupRunning) {
+    return;
+  }
+  cleanupRunning = true;
+
+  let interestingTypesFilter = '';
+  if (interestingTypesSet.size > 0) {
+    const safeInterestingTypesValues = Array.from(interestingTypesSet)
+      .map(sparqlEscapeUri)
+      .join('\n');
+    interestingTypesFilter = `?subject a ?type .
+      VALUES ?type {
+        ${safeInterestingTypesValues}
+      }`;
+  }
+
+  await update(`
+    PREFIX dct: <http://purl.org/dc/terms/>
+
+    DELETE {
+      GRAPH ?g {
+        ?subject dct:modified ?older .
+      }
+    }
+    WHERE {
+      GRAPH ?g {
+        ?subject dct:modified ?older .
+        ?subject dct:modified ?newer .
+        FILTER(?older < ?newer)
+
+        ${interestingTypesFilter}
+      }
+
+      ${filterModifiedSubjects}
+    }
+  `);
+
+  cleanupRunning = false;
+};
+
+if (process.env.CLEANUP_DUPLICATES_CRON) {
+  const cronjob = CronJob.from({
+    cronTime: process.env.CLEANUP_DUPLICATES_CRON,
+    onTick: async () => {
+      await cleanupDuplicateModifieds();
+    },
+  });
+  cronjob.start();
+}
+
+if (process.env.CLEANUP_DUPLICATES_AT_START == 'true') {
+  cleanupDuplicateModifieds();
+}

--- a/config/config.ts
+++ b/config/config.ts
@@ -1,8 +1,6 @@
 import { Changeset } from '../types';
 
-export const interestingTypes = [
-  'http://www.w3.org/2004/02/skos/core#Concept>',
-];
+export const interestingTypes = ['http://www.w3.org/2004/02/skos/core#Concept'];
 
 export const filterModifiedSubjects = '';
 

--- a/docker-compose.debug.yml
+++ b/docker-compose.debug.yml
@@ -1,22 +1,20 @@
 services:
   modified:
-    image: local-js-template
-    #build: ./
+    image: semtech/mu-javascript-template:latest
     restart: 'no'
     labels:
       - 'logging=true'
     environment:
       - NODE_ENV=development
       - NO_BABEL_NODE=true
+      - CLEANUP_DUPLICATES_CRON=0 * * * * # Every hour
+      - CLEANUP_DUPLICATES_AT_START=true
     ports:
       - '8083:80'
       - '9224:9229'
     volumes:
       - ../app-lokaal-mandatenbeheer/config/modified:/config
       - ./:/app
-      # ignore app/dist because this is where we map the built files to, otherwise we get an infinite loop of creating files (on mac)
-      - /app/dist
-      - ./dist:/build/
     networks:
       - debug
 networks:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,23 +1,22 @@
 {
-  "name": "mandataris-service",
+  "name": "track-modified-service",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "mandataris-service",
+      "name": "track-modified-service",
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
         "@lblod/mu-auth-sudo": "^0.6.1",
         "body-parser": "^1.19.0",
-        "cron": "^1.8.2",
+        "cron": "^3.1.7",
         "crypto-js": "^4.0.0",
         "express-promise-router": "^4.1.1",
         "lodash.groupby": "^4.6.0",
         "lodash.uniq": "^4.5.0",
         "moment": "^2.29.1",
-        "multer": "^1.4.5-lts.1",
         "release-it": "^15.4.1",
         "uuid": "^8.3.1"
       },
@@ -565,6 +564,11 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true
     },
+    "node_modules/@types/luxon": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.4.2.tgz",
+      "integrity": "sha512-TifLZlFudklWlMBfhubvgqTXRzLDI5pCbGa4P8a3wPyUQSW+1xQ5eDsreP9DWHX3tjq1ke96uYG/nwundroWcA=="
+    },
     "node_modules/@types/node": {
       "version": "20.12.10",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.10.tgz",
@@ -1058,11 +1062,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/append-field": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
-      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw=="
-    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -1474,11 +1473,6 @@
         "ieee754": "^1.2.1"
       }
     },
-    "node_modules/buffer-from": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
-    },
     "node_modules/bundle-name": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-3.0.0.tgz",
@@ -1491,17 +1485,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/busboy": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
-      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
-      "dependencies": {
-        "streamsearch": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=10.16.0"
       }
     },
     "node_modules/bytes": {
@@ -1695,52 +1678,6 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
-    "node_modules/concat-stream": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-      "engines": [
-        "node >= 0.8"
-      ],
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
-      }
-    },
-    "node_modules/concat-stream/node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
-    },
-    "node_modules/concat-stream/node_modules/readable-stream": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/concat-stream/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-    },
-    "node_modules/concat-stream/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
     "node_modules/config-chain": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
@@ -1859,11 +1796,12 @@
       }
     },
     "node_modules/cron": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/cron/-/cron-1.8.2.tgz",
-      "integrity": "sha512-Gk2c4y6xKEO8FSAUTklqtfSr7oTq0CiPQeLBG5Fl0qoXpZyMcj1SG59YL+hqq04bu6/IuEA7lMkYDAplQNKkyg==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/cron/-/cron-3.5.0.tgz",
+      "integrity": "sha512-0eYZqCnapmxYcV06uktql93wNWdlTmmBFP2iYz+JPVcQqlyFYcn1lFuIk4R54pkOmE7mcldTAPZv6X5XA4Q46A==",
       "dependencies": {
-        "moment-timezone": "^0.5.x"
+        "@types/luxon": "~3.4.0",
+        "luxon": "~3.5.0"
       }
     },
     "node_modules/cross-spawn": {
@@ -4701,6 +4639,14 @@
         "node": ">=10"
       }
     },
+    "node_modules/luxon": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.5.0.tgz",
+      "integrity": "sha512-rh+Zjr6DNfUYR3bPwJEnuwDdqMbxZW7LOQfUN4B54+Cl+0o5zaU9RJ6bcidfDtC1cWCZXQ+nvX8bf6bAji37QQ==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/macos-release": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-3.2.0.tgz",
@@ -4831,17 +4777,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      }
-    },
     "node_modules/moment": {
       "version": "2.29.4",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
@@ -4850,38 +4785,10 @@
         "node": "*"
       }
     },
-    "node_modules/moment-timezone": {
-      "version": "0.5.43",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.43.tgz",
-      "integrity": "sha512-72j3aNyuIsDxdF1i7CEgV2FfxM1r6aaqJyLB2vwb33mXYyoyLly+F1zbWqhA3/bVIoJ4szlUoMbUnVdid32NUQ==",
-      "dependencies": {
-        "moment": "^2.29.4"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
-    },
-    "node_modules/multer": {
-      "version": "1.4.5-lts.1",
-      "resolved": "https://registry.npmjs.org/multer/-/multer-1.4.5-lts.1.tgz",
-      "integrity": "sha512-ywPWvcDMeH+z9gQq5qYHCCy+ethsk4goepZ45GLD63fOu0YcNecQxi64nDs3qluZB+murG3/D4dJ7+dGctcCQQ==",
-      "dependencies": {
-        "append-field": "^1.0.0",
-        "busboy": "^1.0.0",
-        "concat-stream": "^1.5.2",
-        "mkdirp": "^0.5.4",
-        "object-assign": "^4.1.1",
-        "type-is": "^1.6.4",
-        "xtend": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
     },
     "node_modules/mute-stream": {
       "version": "1.0.0",
@@ -5018,14 +4925,6 @@
       "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/object-inspect": {
@@ -5524,11 +5423,6 @@
       "engines": {
         "node": ">=6.0.0"
       }
-    },
-    "node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "node_modules/promise-nodeify": {
       "version": "0.1.0",
@@ -6598,14 +6492,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/streamsearch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
-      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -6948,11 +6834,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/typedarray": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
     },
     "node_modules/typedarray-to-buffer": {
       "version": "3.1.5",
@@ -7438,14 +7319,6 @@
         "is-typedarray": "^1.0.0",
         "signal-exit": "^3.0.2",
         "typedarray-to-buffer": "^3.1.5"
-      }
-    },
-    "node_modules/xtend": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-      "engines": {
-        "node": ">=0.4"
       }
     },
     "node_modules/yallist": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@lblod/mu-auth-sudo": "^0.6.1",
     "body-parser": "^1.19.0",
-    "cron": "^1.8.2",
+    "cron": "^3.1.7",
     "crypto-js": "^4.0.0",
     "express-promise-router": "^4.1.1",
     "lodash.groupby": "^4.6.0",


### PR DESCRIPTION
## Description

add cron to clean up duplicate modified statements in same graph, optional by env var

## How to test
- verify that there are indeed duplicate modifieds using this query:
```SPARQL
  PREFIX dct: <http://purl.org/dc/terms/>
  PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
  SELECT ?s ?mod1 ?mod2 ?diff WHERE {
    GRAPH ?g {
      ?s dct:modified ?mod1.
      ?s dct:modified ?mod2.
    }
    ?g ext:ownedBy ?someone.
    FILTER (?mod1 < ?mod2)
    BIND(?mod2 - ?mod1 as ?diff)
    FILTER(?diff < 300)
  } order by ?s ?diff limit 600
```
- set the cron to every minute
- run cleanup at start
- disable the regular modified service in lmb
- run this one instead
- verify that the duplicates are cleaned up
- verify that the cron query indeed runs every minute
- verify that incoming changes are still taken into account by bulk bekrachtiging of a mandataris (and that the modified is set, without a duplicate being created)
