### PR TITLE
clean duplicate modifieds across graphs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,5 +10,7 @@ The service can be configured using the following exports in the config folder (
 - **filterModifiedSubjects**: an (optional) filter on the query of which subjects to update the modified for. The query contains ?subject, ?type, ?modified (current value, optional) and ?g as variables
 - **filterDeltas**: a function that filters the deltas to act upon. By default, we won't change the modified for a subject if any delta triple (insert or delete) contains a modified for that subject.
 
+This service also has the ability to clean up duplicate modified dates periodically. It does this using a cron job that you can activate by setting the env variable `CLEANUP_DUPLICATES_CRON` to a cron string. You can also clean up at start by setting the env variable `CLEANUP_AT_START` to true. This cleanup process keeps the most recent dct:modified value for any given subject. If there are different modified values in different graphs, it keeps the most recent one and overwrites the older value in the other graphs to this one.
+
 > [!CAUTION]
 > It is possible that we do not receive all deltas related to a change (if the change is split over multiple queries) and therefore might miss the modification date set by the application if it came in another batch of deltas. In that case the modified will still be updated. One can use batching in the delta notifier to mitigate this issue, but it will never completely go away.

--- a/app.ts
+++ b/app.ts
@@ -137,14 +137,21 @@ const cleanupDuplicateModifieds = async () => {
         ?subject dct:modified ?older .
       }
     }
+    INSERT {
+      GRAPH ?g {
+        ?subject dct:modified ?newer .
+      }
+    }
     WHERE {
       GRAPH ?g {
         ?subject dct:modified ?older .
-        ?subject dct:modified ?newer .
-        FILTER(?older < ?newer)
-
         ${interestingTypesFilter}
       }
+      GRAPH ?h {
+        ?subject dct:modified ?newer .
+      }
+      FILTER(?older < ?newer)
+
 
       ${filterModifiedSubjects}
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "track-modified-service",
-  "version": "0.0.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "track-modified-service",
-      "version": "0.0.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@lblod/mu-auth-sudo": "^0.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "track-modified-service",
-  "version": "0.0.0",
+  "version": "0.2.0",
   "description": "Service to set the dct:modified for concepts based on incoming deltas",
   "main": "app.js",
   "author": "redpencil.io",


### PR DESCRIPTION

## Description

Cleans duplicate modified across different graphs. Updates the modified date in the graph with the old date to be the same as the new date.

